### PR TITLE
Hardcode UTF8 parsed string to avoid Mojibake

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -2,9 +2,17 @@ use strict;
 use warnings;
 use Module::Build;
 
+my $abstract = 'Ⓔⓝⓒⓛⓞⓢⓔⓓ Ⓐⓛⓟⓗⓐⓝⓤⓜⓔⓡⓘⓒⓢ Ⓔⓝⓒⓞⓓⓔⓡ';
+if ( $] > 5.008001 ) {
+  utf8::decode($abstract);
+} else {
+  $abstract ='Enclosed Alphanumerics Encoder';
+}
+
 my $builder = Module::Build->new(
     name                => 'Acme-EnclosedChar',
     module_name         => 'Acme::EnclosedChar',
+    dist_abstract       => $abstract,
     license             => 'perl',
     dist_author         => 'Dai Okabayashi <bayashi@cpan.org>',
     dist_version_from   => 'lib/Acme/EnclosedChar.pm',

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Dai Okabayashi <bayashi@cpan.org>"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Module::Build version 0.4005, CPAN::Meta::Converter version 2.132830",
+   "generated_by" : "Module::Build version 0.421",
    "license" : [
       "perl_5"
    ],


### PR DESCRIPTION
The conditional logic is to avoid needing to 'use utf8' which might barf
in the wrong place on earlier perls without configure_requires support.

This could also be done by simply placing the whole text inline on the
'dist_abstract' line and then adding 'use utf8' at the top of the file,
but this approach is slightly more portable.

And I'm not sure what versions of Module::Build support this trick, but
the most recent one on CPAN does.

Hopefully, this commit should resolve #1
